### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Publish NPM
+permissions:
+  contents: read
 on:
   push:
     branches:
@@ -21,6 +23,8 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/j0code/wplace-api/security/code-scanning/2](https://github.com/j0code/wplace-api/security/code-scanning/2)

To fix this issue, add an explicit `permissions` block to the workflow file to scope down the GITHUB_TOKEN's permissions according to each job's needs. As a minimal baseline, the top of the workflow (root) should specify `permissions: contents: read`, which grants read-only access to repository contents for all jobs unless they request more. 

If the `publish-npm` job is responsible for publishing packages and requires broader permissions (such as `contents: write`), add a specific `permissions` block to that job. The `build` job, which just runs tests, only needs read access. 

Implement the fix by:
- Adding `permissions: contents: read` at the root level (after `name` or `on`).
- If required (for npm actions such as creating a release or publishing), set `permissions: contents: write` specifically for the `publish-npm` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
