### PR TITLE
Attempt to fix NPM publish action failing if alr published

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,7 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: Publish NPM
+name: NPM Publish
 permissions:
   contents: read
 on:
@@ -27,11 +27,32 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
+          
+      - name: get pkg name & version
+        id: pkg
+        run: |
+          echo "name=$(node -p \"require('./package.json').name\")" >> $GITHUB_OUTPUT
+          echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          
       - run: npm ci
-      - run: npm publish
+      
+      - name: publish if new version
+        run: |
+          PKG="${{ steps.pkg.outputs.name }}"
+          VER="${{ steps.pkg.outputs.version }}"
+          echo "Checking if $PKG@$VER exists..."
+          if npm view "${PKG}@${VER}" >/dev/null 2>&1; then
+            echo "Package version $VER already published — skipping publish (success)."
+          else
+            echo "Publishing $PKG@$VER..."
+            npm publish
+          fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -38,8 +38,6 @@ jobs:
         run: |
           echo "name=$(node -p \"require('./package.json').name\")" >> $GITHUB_OUTPUT
           echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
           
       - run: npm ci
       


### PR DESCRIPTION
This checks if `name@version` is already published first and only attempts publishing if it is not.

Also fixes naming scheme mismatch between JSR Publish & NPM Publish.